### PR TITLE
<feat>(UI): tab-like style and highlighting

### DIFF
--- a/HardwareConsole/HardwareDelegate.qml
+++ b/HardwareConsole/HardwareDelegate.qml
@@ -9,12 +9,36 @@ ItemDelegate {
     width: parent.width
     height: 50
     checkable: true
-    highlighted: ListView.isCurrentItem
 
     signal setHardware(int index)
 
+    property bool chosen : ListView.view.currentIndex === index
+
     Component.onCompleted: {
         this.setHardware.connect(hardwareSpecificsListView.setHardwareSpecificModelByIndex)
+    }
+
+    background: Item {
+        anchors.fill: parent
+        Rectangle {
+            anchors.fill: parent
+            color: Material.background
+            anchors.bottomMargin: -20
+            anchors.leftMargin: -2
+            anchors.rightMargin: -2
+            border.color: chosen ? "#00BCD4" : "ghostwhite"
+            border.width: 2
+            radius: 10
+        }
+
+        Rectangle {
+            width: parent.width
+            height: 20
+            color: Material.background
+            anchors.bottom: parent.bottom
+            anchors.bottomMargin: -20
+            anchors.horizontalCenter: parent.horizontalCenter
+        }
     }
 
     onClicked: {
@@ -23,6 +47,7 @@ ItemDelegate {
     }
     font.pixelSize: hovered ? 26 : 24
     font.family: "Calibri"
-    font.bold: highlighted
-    text: model.name
+    font.bold: chosen
+    text: chosen ? model.name.toUpperCase() : model.name
+    Material.foreground: chosen ? Material.Cyan : Material.White
 }

--- a/HardwareConsole/HardwareSpecificsDelegate.qml
+++ b/HardwareConsole/HardwareSpecificsDelegate.qml
@@ -9,9 +9,32 @@ ItemDelegate {
     height: chosen ? hardwareSpecificsFunctionListView.height + hardwareSpecificsNameLabel.height : hardwareSpecificsNameLabel.height
     width: hardwareSpecificsListView.width
 
-    checkable: true
+    highlighted: false
 
     onClicked: ListView.view.currentIndex = index
+
+    background: Item {
+        anchors.fill: parent
+        Rectangle {
+            anchors.fill: parent
+            color: Material.background
+            anchors.bottomMargin: -20
+            anchors.leftMargin: -2
+            anchors.rightMargin: -2
+            border.color: Material.theme === Material.Dark ? "ghostwhite" : "midnightblue"
+            border.width: 2
+            radius: 10
+        }
+
+        Rectangle {
+            width: parent.width
+            height: 20
+            color: Material.background
+            anchors.bottom: parent.bottom
+            anchors.bottomMargin: -20
+            anchors.horizontalCenter: parent.horizontalCenter
+        }
+    }
 
     property bool chosen: ListView.isCurrentItem
     property ListModel functions: model.functions

--- a/HardwareConsole/main.qml
+++ b/HardwareConsole/main.qml
@@ -3,6 +3,7 @@ import QtQuick.Window 2.12
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.11
 import QtQml.Models 2.12
+import QtQuick.Controls.Material 2.12
 import JsonReader 1.0
 
 // version 1.0
@@ -29,7 +30,7 @@ ApplicationWindow {
         text: qsTr("Menu")
         font.family: "Arial Black"
         font.pointSize: 30
-        width: 220
+        width: 250
         height: 50
         anchors.left: parent.left
         anchors.top: parent.top
@@ -37,19 +38,9 @@ ApplicationWindow {
         verticalAlignment: Text.AlignVCenter
     }
 
-    Rectangle {
-        id: horizontalSeperator
-        anchors.top: parent.top
-        anchors.left: parent.left
-        anchors.topMargin: menuLabel.height
-        color: "white"
-        width: menuLabel.width
-        height: 5
-    }
-
     ListView {
         id: hardwareListView
-        width: 220
+        width: menuLabel.width
         height: parent.height-menuLabel.height
         anchors.bottom: parent.bottom
         model: ListModel {}
@@ -67,12 +58,13 @@ ApplicationWindow {
     Rectangle {
         id: verticalSeperator
         anchors.top: parent.top
+        anchors.topMargin: 10
         anchors.bottom: parent.bottom
         anchors.left: parent.left
         anchors.leftMargin: hardwareListView.width
-        color: "white"
+        color: Material.theme === Material.Dark ? "white" : "black"
         height: parent.height
-        width: 5
+        width: 2
     }
 
     ListView {
@@ -83,6 +75,9 @@ ApplicationWindow {
         anchors.right: parent.right
         model: ListModel {}
         delegate: HardwareSpecificsDelegate {}
+        Component.onCompleted: {
+            setHardwareSpecificModelByIndex(0)
+        }
 
         function setHardwareSpecificModelByIndex(index) {
             model.clear()

--- a/HardwareConsole/qtquickcontrols2.conf
+++ b/HardwareConsole/qtquickcontrols2.conf
@@ -2,4 +2,3 @@
 Style=Material
 [Material]
 Theme=Dark
-Accent=Red

--- a/user-file/hardwareList.json
+++ b/user-file/hardwareList.json
@@ -47,7 +47,7 @@
             ]
         },
         {
-            "category" : "SignalGenerator",
+            "category" : "Signal Generator",
             "functions" : [
                 {
                     "name" : "Set wave file"


### PR DESCRIPTION
Each hardware category as well as specific hardware will be displayed like a 'tab'. A few geometry changes here and there. Play with the new UI to see for yourself.
- Highlighting: The chosen category will be displayed in cyan (#00BCD4), and capitalized.
- Json file content: "SignalGenerator" to "Signal Generator" (added a space)
- Minor size change: The left column is widened to fit "SIGNAL GENERATOR".